### PR TITLE
Fixes typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ _deps
 
 # Directories
 .vs/
-.vs_code/
+.vscode/
 build/
 .idea/
 


### PR DESCRIPTION
Corrects the directory name in .gitignore from ".vs_code" to ".vscode" to ensure proper exclusion of the Visual Studio Code directory.
